### PR TITLE
Add web UI enhancements: redo log, export, heatmap, records, encryption, a11y

### DIFF
--- a/web/src/components/checksums.js
+++ b/web/src/components/checksums.js
@@ -1,6 +1,7 @@
 // Checksum validation — mirrors `inno checksum`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createChecksums(container, fileData) {
   const wasm = getWasm();
@@ -20,6 +21,7 @@ export function createChecksums(container, fileData) {
     <div class="p-6 space-y-6 overflow-auto max-h-full">
       <div class="flex items-center gap-3">
         <h2 class="text-lg font-bold text-innodb-cyan">Checksum Validation</h2>
+        <span id="checksums-export"></span>
         <span class="${allValid ? 'badge-valid' : 'badge-invalid'} px-2 py-0.5 rounded text-xs font-bold">
           ${allValid ? 'ALL VALID' : `${report.invalid_pages} INVALID`}
         </span>
@@ -55,6 +57,11 @@ export function createChecksums(container, fileData) {
       </div>
     </div>
   `;
+
+  const exportSlot = container.querySelector('#checksums-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => report, 'checksums'));
+  }
 
   const checkbox = container.querySelector('#show-invalid-only');
   const wrap = container.querySelector('#checksum-table-wrap');

--- a/web/src/components/diff.js
+++ b/web/src/components/diff.js
@@ -1,6 +1,7 @@
 // Two-file diff view — mirrors `inno diff`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createDiff(container, fileName1, fileData1, fileName2, fileData2) {
   const wasm = getWasm();
@@ -17,7 +18,10 @@ export function createDiff(container, fileName1, fileData1, fileName2, fileData2
 
   container.innerHTML = `
     <div class="p-6 space-y-6 overflow-auto max-h-full">
-      <h2 class="text-lg font-bold text-innodb-cyan">Tablespace Diff</h2>
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-bold text-innodb-cyan">Tablespace Diff</h2>
+        <span id="diff-export"></span>
+      </div>
 
       <div class="grid grid-cols-2 gap-4">
         <div class="bg-surface-2 rounded-lg p-4">
@@ -32,7 +36,7 @@ export function createDiff(container, fileName1, fileData1, fileName2, fileData2
         </div>
       </div>
 
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
         ${statCard('Identical', result.identical, 'text-innodb-green')}
         ${statCard('Modified', result.modified, result.modified > 0 ? 'text-innodb-amber' : '')}
         ${statCard('Only in File 1', result.only_in_first, result.only_in_first > 0 ? 'text-innodb-red' : '')}
@@ -75,6 +79,11 @@ export function createDiff(container, fileName1, fileData1, fileName2, fileData2
       `}
     </div>
   `;
+
+  const exportSlot = container.querySelector('#diff-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => result, 'diff'));
+  }
 }
 
 function modRow(p) {

--- a/web/src/components/dropzone.js
+++ b/web/src/components/dropzone.js
@@ -12,8 +12,8 @@ export function createDropzone(onFile, onDiffFiles) {
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
         d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
     </svg>
-    <p class="text-lg text-gray-400 mb-2">Drop an .ibd file here to analyze</p>
-    <p class="text-sm text-gray-600 mb-4">or drop two files to diff them</p>
+    <p class="text-lg text-gray-400 mb-2">Drop an .ibd or redo log file to analyze</p>
+    <p class="text-sm text-gray-600 mb-4">or drop two .ibd files to diff them</p>
     <button id="file-btn"
       class="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg text-sm transition-colors">
       Choose File

--- a/web/src/components/heatmap.js
+++ b/web/src/components/heatmap.js
@@ -1,0 +1,216 @@
+// Page type heatmap — canvas-based visualization of page types
+import { getWasm } from '../wasm.js';
+import { esc } from '../utils/html.js';
+
+const PAGE_COLORS = {
+  'INDEX': '#3b82f6',
+  'UNDO_LOG': '#f59e0b',
+  'FSP_HDR': '#22d3ee',
+  'INODE': '#a855f7',
+  'ALLOCATED': '#4b5563',
+  'BLOB': '#f97316',
+  'SDI': '#10b981',
+  'IBUF_BITMAP': '#ec4899',
+  'IBUF_FREE_LIST': '#f472b6',
+  'XDES': '#06b6d4',
+  'TRX_SYS': '#8b5cf6',
+  'SYS': '#6366f1',
+  'ZBLOB': '#fb923c',
+  'ZBLOB2': '#fdba74',
+  'RTREE': '#84cc16',
+  'LOB_FIRST': '#14b8a6',
+  'LOB_DATA': '#2dd4bf',
+  'LOB_INDEX': '#5eead4',
+  'COMPRESSED': '#78716c',
+  'ENCRYPTED': '#ef4444',
+  'COMPRESSED_ENCRYPTED': '#dc2626',
+  'ENCRYPTED_RTREE': '#b91c1c',
+};
+const DEFAULT_COLOR = '#6b7280';
+
+export function createHeatmap(container, fileData) {
+  const wasm = getWasm();
+  let parsed;
+  try {
+    parsed = JSON.parse(wasm.parse_tablespace(fileData));
+  } catch (e) {
+    container.innerHTML = `<div class="p-6 text-red-400">Error parsing tablespace: ${esc(e)}</div>`;
+    return;
+  }
+
+  const pages = parsed.pages;
+  const N = pages.length;
+  if (N === 0) {
+    container.innerHTML = `<div class="p-6 text-gray-500">No pages to display.</div>`;
+    return;
+  }
+
+  // Build type→color map and count
+  const typeCounts = {};
+  for (const p of pages) {
+    typeCounts[p.page_type_name] = (typeCounts[p.page_type_name] || 0) + 1;
+  }
+  const sortedTypes = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);
+
+  container.innerHTML = `
+    <div class="p-6 space-y-4 overflow-auto max-h-full">
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-bold text-innodb-cyan">Page Type Heatmap</h2>
+        <span class="text-xs text-gray-500">${N.toLocaleString()} pages</span>
+        ${N > 1000 ? '<span class="text-xs text-gray-600">Scroll to zoom, drag to pan</span>' : ''}
+      </div>
+      <div id="heatmap-wrap" class="relative bg-surface-1 rounded-lg overflow-hidden" style="height:400px;">
+        <canvas id="heatmap-canvas"></canvas>
+        <div id="heatmap-tooltip" class="absolute hidden pointer-events-none bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 z-10"></div>
+      </div>
+      ${N > 1000 ? '<button id="heatmap-reset" class="px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs">Reset Zoom</button>' : ''}
+      <div id="heatmap-legend" class="flex flex-wrap gap-3 text-xs"></div>
+    </div>
+  `;
+
+  const wrap = container.querySelector('#heatmap-wrap');
+  const canvas = container.querySelector('#heatmap-canvas');
+  const tooltip = container.querySelector('#heatmap-tooltip');
+  const legendEl = container.querySelector('#heatmap-legend');
+  const ctx = canvas.getContext('2d');
+
+  // Layout calculation
+  const cols = Math.ceil(Math.sqrt(N * 1.5));
+  const rows = Math.ceil(N / cols);
+
+  // Zoom/pan state
+  let zoom = 1;
+  let panX = 0;
+  let panY = 0;
+  let dragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragPanX = 0;
+  let dragPanY = 0;
+
+  function cellSize() {
+    const wrapW = wrap.clientWidth;
+    const wrapH = wrap.clientHeight;
+    const raw = Math.min(wrapW / cols, wrapH / rows);
+    return Math.max(2, Math.min(24, raw));
+  }
+
+  function render() {
+    const cs = cellSize() * zoom;
+    canvas.width = wrap.clientWidth;
+    canvas.height = wrap.clientHeight;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const offsetX = panX;
+    const offsetY = panY;
+
+    // Determine visible range
+    const startCol = Math.max(0, Math.floor(-offsetX / cs));
+    const endCol = Math.min(cols, Math.ceil((canvas.width - offsetX) / cs));
+    const startRow = Math.max(0, Math.floor(-offsetY / cs));
+    const endRow = Math.min(rows, Math.ceil((canvas.height - offsetY) / cs));
+
+    for (let row = startRow; row < endRow; row++) {
+      for (let col = startCol; col < endCol; col++) {
+        const idx = row * cols + col;
+        if (idx >= N) break;
+        const p = pages[idx];
+        ctx.fillStyle = PAGE_COLORS[p.page_type_name] || DEFAULT_COLOR;
+        const x = col * cs + offsetX;
+        const y = row * cs + offsetY;
+        if (cs > 3) {
+          ctx.fillRect(x + 0.5, y + 0.5, cs - 1, cs - 1);
+        } else {
+          ctx.fillRect(x, y, cs, cs);
+        }
+      }
+    }
+  }
+
+  function getPageAtMouse(mx, my) {
+    const cs = cellSize() * zoom;
+    const col = Math.floor((mx - panX) / cs);
+    const row = Math.floor((my - panY) / cs);
+    if (col < 0 || col >= cols || row < 0 || row >= rows) return null;
+    const idx = row * cols + col;
+    if (idx >= N) return null;
+    return pages[idx];
+  }
+
+  canvas.addEventListener('mousemove', (e) => {
+    if (dragging) {
+      panX = dragPanX + (e.offsetX - dragStartX);
+      panY = dragPanY + (e.offsetY - dragStartY);
+      requestAnimationFrame(render);
+      tooltip.classList.add('hidden');
+      return;
+    }
+    const p = getPageAtMouse(e.offsetX, e.offsetY);
+    if (p) {
+      tooltip.classList.remove('hidden');
+      tooltip.innerHTML = `<strong>Page ${p.page_number}</strong><br>${esc(p.page_type_name)}<br>LSN: ${p.lsn}`;
+      tooltip.style.left = `${Math.min(e.offsetX + 12, wrap.clientWidth - 150)}px`;
+      tooltip.style.top = `${Math.min(e.offsetY + 12, wrap.clientHeight - 60)}px`;
+    } else {
+      tooltip.classList.add('hidden');
+    }
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    tooltip.classList.add('hidden');
+  });
+
+  if (N > 1000) {
+    canvas.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      const factor = e.deltaY > 0 ? 0.9 : 1.1;
+      const newZoom = Math.max(0.5, Math.min(20, zoom * factor));
+      // Zoom toward mouse position
+      const mx = e.offsetX;
+      const my = e.offsetY;
+      panX = mx - (mx - panX) * (newZoom / zoom);
+      panY = my - (my - panY) * (newZoom / zoom);
+      zoom = newZoom;
+      requestAnimationFrame(render);
+    }, { passive: false });
+
+    canvas.addEventListener('mousedown', (e) => {
+      dragging = true;
+      dragStartX = e.offsetX;
+      dragStartY = e.offsetY;
+      dragPanX = panX;
+      dragPanY = panY;
+      canvas.style.cursor = 'grabbing';
+    });
+
+    window.addEventListener('mouseup', () => {
+      dragging = false;
+      canvas.style.cursor = '';
+    });
+
+    const resetBtn = container.querySelector('#heatmap-reset');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        zoom = 1;
+        panX = 0;
+        panY = 0;
+        requestAnimationFrame(render);
+      });
+    }
+  }
+
+  // Legend
+  legendEl.innerHTML = sortedTypes.map(([name, count]) => {
+    const color = PAGE_COLORS[name] || DEFAULT_COLOR;
+    return `<div class="flex items-center gap-1">
+      <span class="inline-block w-3 h-3 rounded-sm" style="background:${color}"></span>
+      <span class="text-gray-400">${esc(name)}</span>
+      <span class="text-gray-600">(${count})</span>
+    </div>`;
+  }).join('');
+
+  // Initial render + resize handler
+  requestAnimationFrame(render);
+  const ro = new ResizeObserver(() => requestAnimationFrame(render));
+  ro.observe(wrap);
+}

--- a/web/src/components/hex.js
+++ b/web/src/components/hex.js
@@ -1,6 +1,7 @@
 // Hex dump viewer — mirrors `inno dump`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createHex(container, fileData, pageCount) {
   container.innerHTML = `
@@ -24,6 +25,7 @@ export function createHex(container, fileData, pageCount) {
           <span class="text-xs text-gray-600">0 = full page</span>
         </div>
         <button id="hex-go" class="px-3 py-1 bg-innodb-blue hover:bg-blue-600 text-white rounded text-sm">Dump</button>
+        <span id="hex-export"></span>
       </div>
       <div id="hex-output" class="bg-surface-1 rounded-lg p-4 font-mono text-xs overflow-auto max-h-[calc(100vh-16rem)]">
         <span class="text-gray-600">Select a page and click Dump to view hex data.</span>
@@ -37,6 +39,8 @@ export function createHex(container, fileData, pageCount) {
   const goBtn = container.querySelector('#hex-go');
   const output = container.querySelector('#hex-output');
 
+  let lastDumpRaw = '';
+
   function doDump() {
     const wasm = getWasm();
     const page = parseInt(pageInput.value) || 0;
@@ -45,8 +49,10 @@ export function createHex(container, fileData, pageCount) {
 
     try {
       const dump = wasm.hex_dump_page(fileData, page, offset, length);
+      lastDumpRaw = dump;
       output.innerHTML = formatHexDump(dump);
     } catch (e) {
+      lastDumpRaw = '';
       output.innerHTML = `<span class="text-red-400">${esc(String(e))}</span>`;
     }
   }
@@ -57,6 +63,11 @@ export function createHex(container, fileData, pageCount) {
       if (e.key === 'Enter') doDump();
     });
   });
+
+  const exportSlot = container.querySelector('#hex-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => lastDumpRaw, 'hex_dump', { text: true }));
+  }
 
   // Auto-dump page 0
   doDump();

--- a/web/src/components/overview.js
+++ b/web/src/components/overview.js
@@ -1,6 +1,7 @@
 // Tablespace overview — mirrors `inno parse`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createOverview(container, fileData) {
   const wasm = getWasm();
@@ -21,7 +22,10 @@ export function createOverview(container, fileData) {
 
   container.innerHTML = `
     <div class="p-6 space-y-6 overflow-auto max-h-full">
-      <h2 class="text-lg font-bold text-innodb-cyan">Tablespace Overview</h2>
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-bold text-innodb-cyan">Tablespace Overview</h2>
+        <span id="overview-export"></span>
+      </div>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
         ${statCard('File Size', fmtSize(info.file_size))}
         ${statCard('Page Size', fmtSize(info.page_size))}
@@ -37,9 +41,9 @@ export function createOverview(container, fileData) {
         <table class="w-full text-sm">
           <thead>
             <tr class="text-left text-gray-500 border-b border-gray-800">
-              <th class="py-2 pr-4">Type</th>
-              <th class="py-2 pr-4 text-right">Count</th>
-              <th class="py-2 w-full">Distribution</th>
+              <th scope="col" class="py-2 pr-4">Type</th>
+              <th scope="col" class="py-2 pr-4 text-right">Count</th>
+              <th scope="col" class="py-2 w-full">Distribution</th>
             </tr>
           </thead>
           <tbody>
@@ -69,6 +73,14 @@ export function createOverview(container, fileData) {
       </div>
     </div>
   `;
+
+  const exportSlot = container.querySelector('#overview-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(
+      () => ({ info, type_summary: parsed.type_summary }),
+      'overview',
+    ));
+  }
 }
 
 function statCard(label, value) {

--- a/web/src/components/recovery.js
+++ b/web/src/components/recovery.js
@@ -1,6 +1,7 @@
 // Recovery assessment — mirrors `inno recover`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createRecovery(container, fileData) {
   const wasm = getWasm();
@@ -18,7 +19,10 @@ export function createRecovery(container, fileData) {
 
   container.innerHTML = `
     <div class="p-6 space-y-6 overflow-auto max-h-full">
-      <h2 class="text-lg font-bold text-innodb-cyan">Recovery Assessment</h2>
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-bold text-innodb-cyan">Recovery Assessment</h2>
+        <span id="recovery-export"></span>
+      </div>
 
       <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
         ${statCard('Total Pages', total)}
@@ -61,6 +65,11 @@ export function createRecovery(container, fileData) {
       </div>
     </div>
   `;
+
+  const exportSlot = container.querySelector('#recovery-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => report, 'recovery'));
+  }
 
   const checkbox = container.querySelector('#recovery-show-corrupt');
   const wrap = container.querySelector('#recovery-table-wrap');

--- a/web/src/components/redolog.js
+++ b/web/src/components/redolog.js
@@ -1,0 +1,167 @@
+// Redo log analysis — mirrors `inno log`
+import { getWasm } from '../wasm.js';
+import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
+
+export function createRedoLog(container, fileData) {
+  const wasm = getWasm();
+  let report;
+  try {
+    report = JSON.parse(wasm.parse_redo_log(fileData));
+  } catch (e) {
+    container.innerHTML = `<div class="p-6 text-red-400">Error parsing redo log: ${esc(e)}</div>`;
+    return;
+  }
+
+  const fmtSize = (bytes) => {
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${bytes} B`;
+  };
+
+  // Aggregate mlog record type distribution
+  const typeCounts = {};
+  for (const block of report.blocks) {
+    for (const rt of block.record_types) {
+      typeCounts[rt] = (typeCounts[rt] || 0) + 1;
+    }
+  }
+  const typeEntries = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);
+
+  container.innerHTML = `
+    <div class="p-6 space-y-6 overflow-auto max-h-full">
+      <div class="flex items-center gap-3">
+        <h2 class="text-lg font-bold text-innodb-cyan">Redo Log Analysis</h2>
+        <span id="redolog-export"></span>
+      </div>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        ${statCard('File Size', fmtSize(report.file_size))}
+        ${statCard('Total Blocks', report.total_blocks.toLocaleString())}
+        ${statCard('Data Blocks', report.data_blocks.toLocaleString())}
+        ${statCard('Non-Empty', report.blocks.filter(b => b.has_data).length.toLocaleString())}
+      </div>
+
+      ${report.header ? `
+        <h3 class="text-md font-semibold text-gray-300">File Header</h3>
+        <div class="bg-surface-2 rounded-lg p-4">
+          <table class="text-sm">
+            <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">Format</td><td class="py-0.5 text-sm">${esc(String(report.header.format ?? 'N/A'))}</td></tr>
+            <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">Start LSN</td><td class="py-0.5 text-sm">${report.header.start_lsn ?? 'N/A'}</td></tr>
+            <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">Creator</td><td class="py-0.5 text-sm">${esc(String(report.header.creator ?? 'N/A'))}</td></tr>
+          </table>
+        </div>
+      ` : ''}
+
+      ${(report.checkpoint_1 || report.checkpoint_2) ? `
+        <h3 class="text-md font-semibold text-gray-300">Checkpoints</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          ${report.checkpoint_1 ? checkpointCard('Checkpoint 1', report.checkpoint_1) : ''}
+          ${report.checkpoint_2 ? checkpointCard('Checkpoint 2', report.checkpoint_2) : ''}
+        </div>
+      ` : ''}
+
+      ${typeEntries.length > 0 ? `
+        <h3 class="text-md font-semibold text-gray-300">MLOG Record Distribution</h3>
+        <div class="overflow-x-auto max-h-64">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-gray-500 border-b border-gray-800">
+                <th class="py-2 pr-4">Record Type</th>
+                <th class="py-2 pr-4 text-right">Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${typeEntries.map(([name, count]) => `
+                <tr class="border-b border-gray-800/50 hover:bg-surface-2/50">
+                  <td class="py-1.5 pr-4 text-innodb-cyan text-xs">${esc(name)}</td>
+                  <td class="py-1.5 pr-4 text-right">${count}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      ` : ''}
+
+      <div class="flex items-center gap-2 mb-2">
+        <h3 class="text-md font-semibold text-gray-300">Log Blocks</h3>
+        <label class="text-xs text-gray-600 flex items-center gap-1">
+          <input type="checkbox" id="redolog-nonempty" class="rounded bg-gray-800 border-gray-600" />
+          Show non-empty only
+        </label>
+      </div>
+      <div id="redolog-table-wrap" class="overflow-x-auto max-h-96">
+        ${renderBlockTable(report.blocks, false)}
+      </div>
+    </div>
+  `;
+
+  const exportSlot = container.querySelector('#redolog-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => report, 'redolog'));
+  }
+
+  const checkbox = container.querySelector('#redolog-nonempty');
+  const wrap = container.querySelector('#redolog-table-wrap');
+  checkbox.addEventListener('change', () => {
+    wrap.innerHTML = renderBlockTable(report.blocks, checkbox.checked);
+  });
+}
+
+function renderBlockTable(blocks, nonEmptyOnly) {
+  const filtered = nonEmptyOnly ? blocks.filter((b) => b.has_data) : blocks;
+  if (filtered.length === 0) {
+    return `<div class="text-gray-500 text-sm py-4">No blocks to display.</div>`;
+  }
+  return `
+    <table class="w-full text-xs font-mono">
+      <thead class="sticky top-0 bg-gray-950">
+        <tr class="text-left text-gray-500 border-b border-gray-800">
+          <th class="py-1 pr-3">Index</th>
+          <th class="py-1 pr-3">Block No</th>
+          <th class="py-1 pr-3">Flush</th>
+          <th class="py-1 pr-3">Data Len</th>
+          <th class="py-1 pr-3">1st Rec Group</th>
+          <th class="py-1 pr-3">Checksum</th>
+          <th class="py-1 pr-3">Record Types</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${filtered.map(blockRow).join('')}
+      </tbody>
+    </table>`;
+}
+
+function blockRow(b) {
+  const ckClass = b.checksum_valid ? 'text-innodb-green' : 'text-innodb-red';
+  return `
+    <tr class="border-b border-gray-800/30 hover:bg-surface-2/50">
+      <td class="py-1 pr-3 text-gray-400">${b.block_index}</td>
+      <td class="py-1 pr-3">${b.block_no}</td>
+      <td class="py-1 pr-3">${b.flush_flag ? 'Y' : 'N'}</td>
+      <td class="py-1 pr-3">${b.data_len}</td>
+      <td class="py-1 pr-3">${b.first_rec_group}</td>
+      <td class="py-1 pr-3 ${ckClass} font-bold">${b.checksum_valid ? 'OK' : 'FAIL'}</td>
+      <td class="py-1 pr-3 text-gray-500">${b.record_types.map(r => esc(r)).join(', ') || '—'}</td>
+    </tr>`;
+}
+
+function checkpointCard(title, cp) {
+  return `
+    <div class="bg-surface-2 rounded-lg p-4">
+      <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">${esc(title)}</div>
+      <table class="text-sm">
+        <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">Number</td><td class="py-0.5 text-sm">${cp.checkpoint_no ?? 'N/A'}</td></tr>
+        <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">LSN</td><td class="py-0.5 text-sm">${cp.checkpoint_lsn ?? 'N/A'}</td></tr>
+        <tr><td class="pr-4 py-0.5 text-gray-500 text-xs">Offset</td><td class="py-0.5 text-sm">${cp.checkpoint_offset ?? 'N/A'}</td></tr>
+      </table>
+    </div>`;
+}
+
+function statCard(label, value) {
+  return `
+    <div class="bg-surface-2 rounded-lg p-4">
+      <div class="text-xs text-gray-500 uppercase tracking-wide">${esc(label)}</div>
+      <div class="text-lg font-bold text-gray-100 mt-1">${esc(String(value))}</div>
+    </div>`;
+}

--- a/web/src/components/sdi.js
+++ b/web/src/components/sdi.js
@@ -1,6 +1,7 @@
 // SDI metadata viewer — mirrors `inno sdi`
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
+import { createExportBar } from '../utils/export.js';
 
 export function createSdi(container, fileData) {
   const wasm = getWasm();
@@ -33,7 +34,7 @@ export function createSdi(container, fileData) {
       <div class="flex gap-2 mb-2">
         <button id="sdi-expand-all" class="px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs">Expand All</button>
         <button id="sdi-collapse-all" class="px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs">Collapse All</button>
-        <button id="sdi-copy-all" class="px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs">Copy JSON</button>
+        <span id="sdi-export"></span>
       </div>
       <div id="sdi-records" class="space-y-3">
         ${records.map((r, i) => renderRecord(r, i)).join('')}
@@ -60,13 +61,10 @@ export function createSdi(container, fileData) {
     container.querySelectorAll('.sdi-toggle').forEach((b) => (b.textContent = '+'));
   });
 
-  container.querySelector('#sdi-copy-all').addEventListener('click', () => {
-    navigator.clipboard.writeText(JSON.stringify(records, null, 2)).then(() => {
-      const btn = container.querySelector('#sdi-copy-all');
-      btn.textContent = 'Copied!';
-      setTimeout(() => (btn.textContent = 'Copy JSON'), 1500);
-    });
-  });
+  const exportSlot = container.querySelector('#sdi-export');
+  if (exportSlot) {
+    exportSlot.appendChild(createExportBar(() => records, 'sdi'));
+  }
 }
 
 function renderRecord(record, idx) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,7 +1,7 @@
 // App initialization — WASM loading, routing, component orchestration
 import { initWasm, getWasm } from './wasm.js';
 import { esc } from './utils/html.js';
-import { initTheme } from './utils/theme.js';
+import { initTheme, createThemeToggle } from './utils/theme.js';
 import { initKeyboard } from './utils/keyboard.js';
 import { createDropzone } from './components/dropzone.js';
 import { createTabs, setActiveTab, getTabId, getTabCount } from './components/tabs.js';
@@ -12,6 +12,9 @@ import { createSdi } from './components/sdi.js';
 import { createHex } from './components/hex.js';
 import { createDiff } from './components/diff.js';
 import { createRecovery } from './components/recovery.js';
+import { createRedoLog } from './components/redolog.js';
+import { createHeatmap } from './components/heatmap.js';
+import { downloadJson } from './utils/export.js';
 
 import './style.css';
 
@@ -21,6 +24,9 @@ let fileData = null;
 let fileName = null;
 let diffData = null; // { name1, data1, name2, data2 }
 let pageCount = 0;
+let isRedoLog = false;
+let decryptedData = null;
+let encryptionInfo = null;
 
 // ── Bootstrap ────────────────────────────────────────────────────────
 initTheme();
@@ -39,6 +45,17 @@ initTheme();
 })();
 
 initKeyboard(switchTab);
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function tabOpts() {
+  return { showDiff: !!diffData, showRedoLog: isRedoLog };
+}
+
+/** Returns the effective data for analysis (decrypted if available). */
+function effectiveData() {
+  return decryptedData || fileData;
+}
 
 // ── Views ────────────────────────────────────────────────────────────
 
@@ -72,12 +89,36 @@ function onFile(name, data) {
   fileName = name;
   fileData = data;
   diffData = null;
+  isRedoLog = false;
+  decryptedData = null;
+  encryptionInfo = null;
+
+  const wasm = getWasm();
+
+  // Try tablespace first, then redo log
   try {
-    const info = JSON.parse(getWasm().get_tablespace_info(data));
+    const info = JSON.parse(wasm.get_tablespace_info(data));
     pageCount = info.page_count;
+
+    // Check for encryption
+    if (info.is_encrypted) {
+      try {
+        encryptionInfo = JSON.parse(wasm.get_encryption_info(data));
+      } catch {
+        // Encryption info parsing optional
+      }
+    }
   } catch {
-    pageCount = 0;
+    // Not a tablespace — try redo log
+    try {
+      JSON.parse(wasm.parse_redo_log(data));
+      isRedoLog = true;
+      pageCount = 0;
+    } catch {
+      pageCount = 0;
+    }
   }
+
   currentTab = 0;
   renderAnalyzer();
 }
@@ -86,6 +127,9 @@ function onDiffFiles(name1, data1, name2, data2) {
   fileName = name1;
   fileData = data1;
   diffData = { name1, data1, name2, data2 };
+  isRedoLog = false;
+  decryptedData = null;
+  encryptionInfo = null;
   try {
     const info = JSON.parse(getWasm().get_tablespace_info(data1));
     pageCount = info.page_count;
@@ -96,36 +140,104 @@ function onDiffFiles(name1, data1, name2, data2) {
   renderAnalyzer();
 }
 
+function onDecrypt(kData) {
+  try {
+    const wasm = getWasm();
+    const result = wasm.decrypt_tablespace(fileData, kData);
+    decryptedData = result;
+    // Update page count from decrypted data
+    try {
+      const info = JSON.parse(wasm.get_tablespace_info(decryptedData));
+      pageCount = info.page_count;
+    } catch { /* keep existing */ }
+    renderAnalyzer();
+  } catch (e) {
+    // Show error in keyring area
+    const errEl = document.getElementById('keyring-error');
+    if (errEl) errEl.textContent = `Decryption failed: ${e}`;
+  }
+}
+
 function renderAnalyzer() {
   app.innerHTML = '';
+  const opts = tabOpts();
 
   // Header with file name + back button
   const header = document.createElement('header');
   header.className = 'flex items-center justify-between px-6 py-3 border-b border-gray-800';
-  header.innerHTML = `
-    <div class="flex items-center gap-3">
-      <button id="back-btn" class="text-gray-500 hover:text-gray-300 transition-colors" title="Back to file picker">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-        </svg>
-      </button>
-      <h1 class="text-lg font-bold text-innodb-cyan">InnoDB Analyzer</h1>
-      <span class="text-sm text-gray-400 truncate max-w-xs">${esc(fileName)}</span>
-      ${diffData ? `<span class="text-xs text-innodb-amber">+ ${esc(diffData.name2)}</span>` : ''}
-    </div>
-    <div class="text-xs text-gray-600">${pageCount} pages</div>
+
+  const leftDiv = document.createElement('div');
+  leftDiv.className = 'flex items-center gap-3';
+  leftDiv.innerHTML = `
+    <button id="back-btn" class="text-gray-500 hover:text-gray-300 transition-colors" title="Back to file picker" aria-label="Back to file picker">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+    <h1 class="text-lg font-bold text-innodb-cyan">InnoDB Analyzer</h1>
+    <span class="text-sm text-gray-400 truncate max-w-xs">${esc(fileName)}</span>
+    ${diffData ? `<span class="text-xs text-innodb-amber">+ ${esc(diffData.name2)}</span>` : ''}
+    ${encryptionInfo && !decryptedData ? '<span class="text-xs px-2 py-0.5 rounded bg-innodb-amber/20 text-innodb-amber">Encrypted</span>' : ''}
+    ${decryptedData ? '<span class="text-xs px-2 py-0.5 rounded bg-innodb-green/20 text-innodb-green">Decrypted</span>' : ''}
   `;
+
+  const rightDiv = document.createElement('div');
+  rightDiv.className = 'flex items-center gap-3';
+  if (!isRedoLog) {
+    rightDiv.innerHTML = `<div class="text-xs text-gray-600">${pageCount} pages</div>`;
+  }
+
+  // Export All button (not for redo logs)
+  if (!isRedoLog && fileData) {
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
+    exportBtn.textContent = 'Export All';
+    exportBtn.addEventListener('click', () => exportAll());
+    rightDiv.appendChild(exportBtn);
+  }
+
+  rightDiv.appendChild(createThemeToggle());
+  header.appendChild(leftDiv);
+  header.appendChild(rightDiv);
   app.appendChild(header);
 
   header.querySelector('#back-btn').addEventListener('click', () => {
     fileData = null;
     diffData = null;
+    isRedoLog = false;
+      decryptedData = null;
+    encryptionInfo = null;
     showDropzone();
   });
 
+  // Encryption keyring upload banner
+  if (encryptionInfo && !decryptedData && !isRedoLog) {
+    const banner = document.createElement('div');
+    banner.className = 'px-6 py-3 bg-innodb-amber/10 border-b border-innodb-amber/30 flex items-center gap-4 flex-wrap';
+    banner.innerHTML = `
+      <div class="text-sm text-innodb-amber">
+        Encrypted tablespace — Server UUID: <span class="font-mono text-xs">${esc(encryptionInfo.server_uuid || 'N/A')}</span>,
+        Key ID: ${encryptionInfo.master_key_id ?? 'N/A'}
+      </div>
+      <label class="px-3 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs cursor-pointer">
+        Upload Keyring
+        <input type="file" id="keyring-input" class="hidden" />
+      </label>
+      <span id="keyring-error" class="text-xs text-innodb-red"></span>
+    `;
+    app.appendChild(banner);
+
+    banner.querySelector('#keyring-input').addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => onDecrypt(new Uint8Array(reader.result));
+      reader.readAsArrayBuffer(file);
+    });
+  }
+
   // Tabs
-  const showDiff = !!diffData;
-  const tabNav = createTabs(switchTab, { showDiff });
+  const tabNav = createTabs(switchTab, opts);
   app.appendChild(tabNav);
   setActiveTab(tabNav, currentTab);
 
@@ -133,13 +245,15 @@ function renderAnalyzer() {
   const content = document.createElement('div');
   content.id = 'tab-content';
   content.className = 'flex-1 overflow-hidden';
+  content.setAttribute('role', 'tabpanel');
+  content.setAttribute('aria-labelledby', getTabId(currentTab, opts) || '');
   app.appendChild(content);
 
   renderTab();
 }
 
 function switchTab(index) {
-  const maxTab = getTabCount(!!diffData) - 1;
+  const maxTab = getTabCount(tabOpts()) - 1;
   if (index < 0 || index > maxTab) return;
   if (!fileData) return;
   currentTab = index;
@@ -153,25 +267,29 @@ function renderTab() {
   if (!content || !fileData) return;
   content.innerHTML = '';
 
-  const id = getTabId(currentTab);
+  const data = effectiveData();
+  const id = getTabId(currentTab, tabOpts());
   switch (id) {
     case 'overview':
-      createOverview(content, fileData);
+      createOverview(content, data);
       break;
     case 'pages':
-      createPages(content, fileData);
+      createPages(content, data);
       break;
     case 'checksums':
-      createChecksums(content, fileData);
+      createChecksums(content, data);
       break;
     case 'sdi':
-      createSdi(content, fileData);
+      createSdi(content, data);
       break;
     case 'hex':
-      createHex(content, fileData, pageCount);
+      createHex(content, data, pageCount);
       break;
     case 'recovery':
-      createRecovery(content, fileData);
+      createRecovery(content, data);
+      break;
+    case 'heatmap':
+      createHeatmap(content, data);
       break;
     case 'diff':
       if (diffData) {
@@ -180,6 +298,22 @@ function renderTab() {
         content.innerHTML = `<div class="p-6 text-gray-500">Drop two files to compare them.</div>`;
       }
       break;
+    case 'redolog':
+      createRedoLog(content, fileData);
+      break;
   }
 }
 
+function exportAll() {
+  const wasm = getWasm();
+  const data = effectiveData();
+  const result = {};
+  try { result.overview = JSON.parse(wasm.get_tablespace_info(data)); } catch { /* skip */ }
+  try { result.pages = JSON.parse(wasm.analyze_pages(data, -1)); } catch { /* skip */ }
+  try { result.checksums = JSON.parse(wasm.validate_checksums(data)); } catch { /* skip */ }
+  try { result.sdi = JSON.parse(wasm.extract_sdi(data)); } catch { /* skip */ }
+  try { result.recovery = JSON.parse(wasm.assess_recovery(data)); } catch { /* skip */ }
+
+  const baseName = fileName.replace(/\.[^.]+$/, '');
+  downloadJson(result, `${baseName}_analysis`);
+}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -38,3 +38,39 @@
   border-color: var(--color-innodb-cyan);
   background: rgba(34, 211, 238, 0.05);
 }
+
+/* Accessibility — focus outlines */
+:focus-visible {
+  outline: 2px solid var(--color-innodb-cyan);
+  outline-offset: 2px;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-spin { animation: none; }
+  * { transition-duration: 0.01ms !important; }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: high) {
+  .border-gray-800, .border-gray-800\/30, .border-gray-800\/50 {
+    border-color: #9ca3af;
+  }
+  .text-gray-500, .text-gray-600 { color: #d1d5db; }
+}
+
+/* Touch-friendly targets */
+@media (pointer: coarse) {
+  button, [role="tab"], label {
+    min-height: 44px;
+    min-width: 44px;
+  }
+  nav { scrollbar-width: none; }
+  nav::-webkit-scrollbar { display: none; }
+}
+
+/* Mobile tab bar scroll snap */
+@media (max-width: 640px) {
+  nav { scroll-snap-type: x mandatory; }
+  nav button { scroll-snap-align: start; }
+}

--- a/web/src/utils/export.js
+++ b/web/src/utils/export.js
@@ -1,0 +1,85 @@
+// Export utilities — JSON download, text download, clipboard copy
+
+/**
+ * Download data as a JSON file.
+ * @param {*} data - Data to serialize as JSON
+ * @param {string} filename - Download filename (without extension)
+ */
+export function downloadJson(data, filename) {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  triggerDownload(blob, `${filename}.json`);
+}
+
+/**
+ * Download raw text as a file.
+ * @param {string} text - Text content
+ * @param {string} filename - Download filename (with extension)
+ */
+export function downloadText(text, filename) {
+  const blob = new Blob([text], { type: 'text/plain' });
+  triggerDownload(blob, filename);
+}
+
+/**
+ * Copy text to clipboard with button feedback.
+ * @param {string} text - Text to copy
+ * @param {HTMLElement} buttonEl - Button element for "Copied!" flash
+ */
+export function copyToClipboard(text, buttonEl) {
+  navigator.clipboard.writeText(text).then(() => {
+    const original = buttonEl.textContent;
+    buttonEl.textContent = 'Copied!';
+    setTimeout(() => { buttonEl.textContent = original; }, 1500);
+  });
+}
+
+/**
+ * Create an export bar with Download and Copy buttons.
+ * @param {() => *} getData - Callback returning data (called lazily on click)
+ * @param {string} baseFilename - Base filename for downloads (without extension)
+ * @param {{ text?: boolean }} [opts] - If text is true, download as .txt instead of .json
+ * @returns {HTMLElement}
+ */
+export function createExportBar(getData, baseFilename, opts = {}) {
+  const el = document.createElement('div');
+  el.className = 'flex items-center gap-2';
+
+  const dlBtn = document.createElement('button');
+  dlBtn.className = 'px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
+  dlBtn.textContent = 'Download';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.className = 'px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
+  copyBtn.textContent = 'Copy';
+
+  dlBtn.addEventListener('click', () => {
+    const data = getData();
+    if (opts.text) {
+      downloadText(String(data), `${baseFilename}.txt`);
+    } else {
+      downloadJson(data, baseFilename);
+    }
+  });
+
+  copyBtn.addEventListener('click', () => {
+    const data = getData();
+    const text = opts.text ? String(data) : JSON.stringify(data, null, 2);
+    copyToClipboard(text, copyBtn);
+  });
+
+  el.appendChild(dlBtn);
+  el.appendChild(copyBtn);
+  return el;
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/web/src/utils/keyboard.js
+++ b/web/src/utils/keyboard.js
@@ -6,10 +6,20 @@ export function initKeyboard(onTabSwitch) {
     // Don't capture when typing in inputs
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
 
-    // Number keys 1-7 switch tabs
-    if (e.key >= '1' && e.key <= '7' && !e.ctrlKey && !e.metaKey) {
+    // Number keys 1-9 switch tabs
+    if (e.key >= '1' && e.key <= '9' && !e.ctrlKey && !e.metaKey) {
       e.preventDefault();
       onTabSwitch(parseInt(e.key) - 1);
+      return;
+    }
+
+    // Escape returns to dropzone
+    if (e.key === 'Escape' && !e.ctrlKey && !e.metaKey) {
+      const backBtn = document.getElementById('back-btn');
+      if (backBtn) {
+        e.preventDefault();
+        backBtn.click();
+      }
       return;
     }
 

--- a/web/src/utils/theme.js
+++ b/web/src/utils/theme.js
@@ -19,3 +19,18 @@ export function toggleTheme() {
   const isLight = document.documentElement.classList.toggle('light');
   localStorage.setItem(STORAGE_KEY, isLight ? 'light' : 'dark');
 }
+
+export function createThemeToggle() {
+  const btn = document.createElement('button');
+  btn.className = 'px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
+  btn.setAttribute('aria-label', 'Toggle theme');
+  btn.setAttribute('aria-pressed', String(document.documentElement.classList.contains('light')));
+  btn.textContent = document.documentElement.classList.contains('light') ? 'Dark' : 'Light';
+  btn.addEventListener('click', () => {
+    toggleTheme();
+    const isLight = document.documentElement.classList.contains('light');
+    btn.setAttribute('aria-pressed', String(isLight));
+    btn.textContent = isLight ? 'Dark' : 'Light';
+  });
+  return btn;
+}


### PR DESCRIPTION
## Summary

Implements Epic #20 — 6 web UI enhancements across 4 batches:

- **Redo Log tab (#21)**: Full `ib_logfile` analysis with header, checkpoints, MLOG record distribution, and filterable block table
- **Export functionality (#31)**: Download/Copy buttons on all 8 tabs + Export All in analyzer header
- **Page type heatmap (#25)**: Canvas-based visualization with color palette, tooltips, zoom/pan for large tablespaces, and legend
- **Record inspection (#23)**: "View Records" button on INDEX pages showing compact record chain via new `inspect_index_records` WASM function
- **Encrypted tablespace support (#29)**: Keyring upload with `get_encryption_info` and `decrypt_tablespace` WASM functions; decrypted data flows transparently to all tabs
- **Mobile & accessibility (#32)**: ARIA tablist pattern with arrow key navigation, focus outlines, reduced motion, high contrast media queries, touch targets, visible theme toggle

### New WASM functions
| Function | Input | Output |
|----------|-------|--------|
| `inspect_index_records(data, page_num)` | `&[u8], u64` | JSON string |
| `get_encryption_info(data)` | `&[u8]` | JSON string |
| `decrypt_tablespace(data, keyring_data)` | `&[u8], &[u8]` | `Vec<u8>` (Uint8Array) |

### New files
- `web/src/components/redolog.js` — Redo log analysis tab
- `web/src/components/heatmap.js` — Canvas page type heatmap
- `web/src/utils/export.js` — JSON/text download + clipboard utilities

### Changes
- 17 files changed, +1,071 / -53 lines

## Test plan

- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo test` — 322 tests pass (131 unit + 130 integration + 60 doc + 1 compile-only)
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features` — clean
- [x] `cd web && npm run build` — clean (22 modules)
- [ ] Manual: Load `.ibd` file, verify all 7 original tabs + Heatmap tab work
- [ ] Manual: Load `ib_logfile0`, verify Redo Log tab renders
- [ ] Manual: Test Download/Copy buttons on each tab
- [ ] Manual: Test Export All button
- [ ] Manual: Load encrypted `.ibd`, upload keyring, verify decryption
- [ ] Manual: Test keyboard navigation (1-8 tabs, arrow keys, Escape, D for theme)
- [ ] Manual: Test on mobile viewport / touch device
- [ ] Manual: Click "View Records" on an INDEX page detail