### PR TITLE
Add GA4 analytics tracking to web UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,6 +11,13 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ringo380.github.io/idb-utils/" />
     <link rel="icon" href="/idb-utils/favicon.svg" type="image/svg+xml" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SMQDMQW24Y"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SMQDMQW24Y');
+    </script>
   </head>
   <body class="h-full bg-gray-950 text-gray-100 font-mono antialiased">
     <div id="app" class="h-full flex flex-col"></div>

--- a/web/src/components/audit.js
+++ b/web/src/components/audit.js
@@ -3,6 +3,7 @@ import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
 import { renderIndexTable } from '../utils/health-ui.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 /**
  * Create the audit dashboard, analyzing multiple .ibd files.
@@ -257,12 +258,14 @@ function buildAuditDashboard(container, files) {
   const statusSelect = container.querySelector('#audit-filter-status');
   if (nameInput) {
     nameInput.addEventListener('input', () => {
+      trackFeatureUse('audit_filter', { type: 'name' });
       filterName = nameInput.value;
       renderTable();
     });
   }
   if (statusSelect) {
     statusSelect.addEventListener('change', () => {
+      trackFeatureUse('audit_filter', { type: 'status', value: statusSelect.value });
       filterStatus = statusSelect.value;
       renderTable();
     });

--- a/web/src/components/binlog.js
+++ b/web/src/components/binlog.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const PAGE_SIZE = 100;
 
@@ -123,7 +124,7 @@ export function createBinlog(container, fileData) {
       });
     }
 
-    filterInput.addEventListener('input', applyFilter);
+    filterInput.addEventListener('input', () => { trackFeatureUse('binlog_filter'); applyFilter(); });
     renderEvents();
   }
 }

--- a/web/src/components/checksums.js
+++ b/web/src/components/checksums.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createChecksums(container, fileData) {
   const wasm = getWasm();
@@ -16,6 +17,7 @@ export function createChecksums(container, fileData) {
   const total = report.total_pages;
   const validPct = total > 0 ? ((report.valid_pages / total) * 100).toFixed(1) : '0';
   const allValid = report.invalid_pages === 0;
+  trackFeatureUse('checksum_validation', { total, valid: report.valid_pages, invalid: report.invalid_pages });
 
   container.innerHTML = `
     <div class="p-6 space-y-6 overflow-auto max-h-full">

--- a/web/src/components/compat.js
+++ b/web/src/components/compat.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const TARGET_VERSIONS = ['5.7.0', '8.0.0', '8.4.0', '9.0.0', '9.1.0'];
 
@@ -128,6 +129,7 @@ export function createCompat(container, fileData) {
   const versionSelect = container.querySelector('#compat-version-select');
   versionSelect.addEventListener('change', () => {
     selectedVersion = versionSelect.value;
+    trackFeatureUse('compat_version_select', { version: selectedVersion });
     runCheck();
   });
 }

--- a/web/src/components/dropzone.js
+++ b/web/src/components/dropzone.js
@@ -1,4 +1,5 @@
 // Drag-and-drop file input for .ibd files
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const MAX_FILE_SIZE = 500 * 1024 * 1024; // 500 MB
 
@@ -24,7 +25,7 @@ export function createDropzone(onFile, onDiffFiles, onMultiFiles) {
   const input = el.querySelector('#file-input');
   const btn = el.querySelector('#file-btn');
 
-  btn.addEventListener('click', () => input.click());
+  btn.addEventListener('click', () => { trackFeatureUse('upload_method', { method: 'click' }); input.click(); });
   input.addEventListener('change', () => handleFiles(input.files));
 
   el.addEventListener('dragover', (e) => {
@@ -37,6 +38,7 @@ export function createDropzone(onFile, onDiffFiles, onMultiFiles) {
   el.addEventListener('drop', (e) => {
     e.preventDefault();
     el.classList.remove('dropzone-active');
+    trackFeatureUse('upload_method', { method: 'drag_drop' });
     handleFiles(e.dataTransfer.files);
   });
 

--- a/web/src/components/health.js
+++ b/web/src/components/health.js
@@ -5,6 +5,7 @@ import { createExportBar } from '../utils/export.js';
 import { fillFactorClass } from '../utils/health-ui.js';
 import { requestIndexFilter, navigateToTab } from '../utils/navigation.js';
 import { createBTree } from './btree.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 /**
  * Create the health dashboard for a single tablespace file.
@@ -143,6 +144,7 @@ export function createHealth(container, fileData) {
       tr.classList.add('cursor-pointer');
       tr.addEventListener('click', () => {
         const indexId = parseInt(tr.dataset.indexId, 10);
+        trackFeatureUse('health_index_click', { index_id: indexId });
         requestIndexFilter(indexId);
         navigateToTab('pages');
       });
@@ -167,6 +169,7 @@ export function createHealth(container, fileData) {
     }
     const isHidden = btreeContainer.classList.toggle('hidden');
     btreeBtn.textContent = isHidden ? 'Show B+Tree' : 'Hide B+Tree';
+    if (!isHidden) trackFeatureUse('btree_toggle');
   });
 }
 

--- a/web/src/components/heatmap.js
+++ b/web/src/components/heatmap.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { requestPage, navigateToTab } from '../utils/navigation.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const PAGE_COLORS = {
   'INDEX': '#3b82f6',
@@ -310,6 +311,7 @@ export function createHeatmap(container, fileData, onPageClick, diffResult = nul
   // Color mode selector
   modeSelect.addEventListener('change', () => {
     colorMode = modeSelect.value;
+    trackFeatureUse('heatmap_mode', { mode: colorMode });
     if (colorMode === 'checksum') loadChecksums();
     updateLegend();
     requestAnimationFrame(render);
@@ -406,6 +408,7 @@ export function createHeatmap(container, fileData, onPageClick, diffResult = nul
   const tlTooltip = container.querySelector('#lsn-timeline-tooltip');
   const tlCtx = tlCanvas.getContext('2d');
   let tlVisible = false;
+  tlToggle.addEventListener('click', () => { trackFeatureUse('lsn_timeline_toggle'); });
 
   // Filter out pages with LSN === 0 for the scatter plot
   const tlPages = pages.filter(p => p.lsn > 0);

--- a/web/src/components/hex.js
+++ b/web/src/components/hex.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createHex(container, fileData, pageCount) {
   container.innerHTML = `
@@ -57,7 +58,7 @@ export function createHex(container, fileData, pageCount) {
     }
   }
 
-  goBtn.addEventListener('click', doDump);
+  goBtn.addEventListener('click', () => { trackFeatureUse('hex_dump'); doDump(); });
   [pageInput, offsetInput, lengthInput].forEach((input) => {
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') doDump();

--- a/web/src/components/pages.js
+++ b/web/src/components/pages.js
@@ -3,6 +3,7 @@ import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar, downloadText, downloadJson, copyToClipboard } from '../utils/export.js';
 import { consumeRequestedPage, consumeIndexFilter } from '../utils/navigation.js';
+import { trackFeatureUse, trackExport } from '../utils/analytics.js';
 
 export function createPages(container, fileData) {
   const wasm = getWasm();
@@ -118,6 +119,7 @@ export function createPages(container, fileData) {
           recsDiv.classList.remove('hidden');
           viewRecsBtn.textContent = 'Hide Records';
           recsDiv.innerHTML = renderRecords(report);
+          trackFeatureUse('view_records', { page: num });
         } catch (e) {
           recsDiv.classList.remove('hidden');
           recsDiv.innerHTML = `<div class="text-red-400 text-xs py-2">Error: ${esc(String(e))}</div>`;
@@ -156,9 +158,43 @@ export function createPages(container, fileData) {
           decodedBtn.textContent = 'Hide Decoded';
           decodedDiv.innerHTML = renderDecodedRecords(decoded);
           toggleExportButtons(detail, true);
+          trackFeatureUse('decoded_records', { page: num });
         } catch (e) {
           decodedDiv.classList.remove('hidden');
           decodedDiv.innerHTML = `<div class="text-red-400 text-xs py-2">Error: ${esc(String(e))}</div>`;
+        }
+      });
+    }
+
+    // Wire up LOB chain inspector button
+    const lobChainBtn = detail.querySelector('#lob-chain-btn');
+    if (lobChainBtn) {
+      lobChainBtn.addEventListener('click', () => {
+        const lobDiv = detail.querySelector('#lob-chain-section');
+        if (!lobDiv) return;
+        if (lobDiv.dataset.loaded === 'true') {
+          lobDiv.classList.toggle('hidden');
+          lobChainBtn.textContent = lobDiv.classList.contains('hidden') ? 'Inspect LOB Chain' : 'Hide LOB Chain';
+          return;
+        }
+        try {
+          const raw = wasm.analyze_lob_chain(fileData, BigInt(num));
+          if (raw === 'null') {
+            lobDiv.classList.remove('hidden');
+            lobDiv.innerHTML = `<div class="text-gray-500 text-xs py-2">Not a LOB start page or chain could not be traversed.</div>`;
+            lobDiv.dataset.loaded = 'true';
+            lobChainBtn.textContent = 'Hide LOB Chain';
+            return;
+          }
+          const chain = JSON.parse(raw);
+          lobDiv.dataset.loaded = 'true';
+          lobDiv.classList.remove('hidden');
+          lobChainBtn.textContent = 'Hide LOB Chain';
+          lobDiv.innerHTML = renderLobChain(chain);
+          trackFeatureUse('lob_chain', { page: num });
+        } catch (e) {
+          lobDiv.classList.remove('hidden');
+          lobDiv.innerHTML = `<div class="text-red-400 text-xs py-2">Error: ${esc(String(e))}</div>`;
         }
       });
     }
@@ -170,6 +206,7 @@ export function createPages(container, fileData) {
         const decoded = decodedCache[num];
         if (!decoded) return;
         const csv = generateCsv(decoded);
+        trackExport('csv', 'pages');
         downloadText(csv, 'records.csv');
       });
     }
@@ -180,6 +217,7 @@ export function createPages(container, fileData) {
       dlJsonBtn.addEventListener('click', () => {
         const decoded = decodedCache[num];
         if (!decoded) return;
+        trackExport('json', 'pages');
         downloadJson(decoded, 'records');
       });
     }
@@ -191,6 +229,7 @@ export function createPages(container, fileData) {
         const decoded = decodedCache[num];
         if (!decoded) return;
         const sql = generateSqlInserts(decoded);
+        trackFeatureUse('copy_sql', { tab: 'pages' });
         copyToClipboard(sql, copySqlBtn);
       });
     }
@@ -276,6 +315,13 @@ function renderDetail(p) {
       'Data Len': p.lob_header.data_len,
       'TRX ID': p.lob_header.trx_id,
     }));
+  }
+  if (p.is_lob_start) {
+    extra += `
+      <div class="mt-2">
+        <button id="lob-chain-btn" class="px-2 py-1 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs">Inspect LOB Chain</button>
+      </div>
+      <div id="lob-chain-section" class="hidden mt-2"></div>`;
   }
 
   return `
@@ -419,6 +465,51 @@ function generateSqlInserts(decoded) {
     }).join(', ');
     return `INSERT INTO ${quotedTable} (${quotedCols}) VALUES (${values});`;
   }).join('\n');
+}
+
+function renderLobChain(chain) {
+  if (!chain || chain.page_count === 0) {
+    return `<div class="text-yellow-400 text-xs py-2">⚠ LOB chain appears broken or empty (0 pages).</div>`;
+  }
+  const summary = kvTable({
+    'Chain Type': chain.chain_type,
+    'First Page': chain.first_page,
+    'Total Pages': chain.page_count,
+    'Total Data': `${chain.total_data_len} bytes`,
+  });
+  const typeColor = (t) => {
+    if (t.includes('LOB_FIRST') || t.includes('ZLOB_FIRST')) return 'text-innodb-cyan';
+    if (t.includes('LOB_DATA') || t.includes('ZLOB_DATA')) return 'text-green-400';
+    if (t.includes('BLOB') || t.includes('ZBLOB')) return 'text-blue-400';
+    return 'text-gray-300';
+  };
+  const rows = chain.pages.map((cp, i) => {
+    const connector = i === 0 ? '\u250c' : i === chain.pages.length - 1 ? '\u2514' : '\u2502';
+    return `
+      <tr class="border-b border-gray-800/30">
+        <td class="py-0.5 pr-2 text-gray-500 text-right">${i}</td>
+        <td class="py-0.5 pr-2 text-gray-600 font-mono">${connector}</td>
+        <td class="py-0.5 pr-2">${cp.page_no}</td>
+        <td class="py-0.5 pr-2 ${typeColor(cp.page_type)}">${esc(cp.page_type)}</td>
+        <td class="py-0.5 pr-2 text-right">${cp.data_len}</td>
+      </tr>`;
+  }).join('');
+  return `
+    ${section('LOB Chain Summary', summary)}
+    <div class="overflow-x-auto max-h-64 mt-2">
+      <table class="w-full text-xs font-mono">
+        <thead class="sticky top-0 bg-gray-950">
+          <tr class="text-left text-gray-500 border-b border-gray-800">
+            <th scope="col" class="py-1 pr-2">#</th>
+            <th scope="col" class="py-1 pr-2"></th>
+            <th scope="col" class="py-1 pr-2">Page</th>
+            <th scope="col" class="py-1 pr-2">Type</th>
+            <th scope="col" class="py-1 pr-2 text-right">Data Len</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
 }
 
 function section(title, content) {

--- a/web/src/components/recovery.js
+++ b/web/src/components/recovery.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createRecovery(container, fileData) {
   const wasm = getWasm();
@@ -74,6 +75,7 @@ export function createRecovery(container, fileData) {
   const checkbox = container.querySelector('#recovery-show-corrupt');
   const wrap = container.querySelector('#recovery-table-wrap');
   checkbox.addEventListener('change', () => {
+    trackFeatureUse('recovery_filter', { corrupt_only: checkbox.checked });
     wrap.innerHTML = renderTable(report.pages, checkbox.checked);
   });
 }

--- a/web/src/components/redolog.js
+++ b/web/src/components/redolog.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createRedoLog(container, fileData) {
   const wasm = getWasm();
@@ -104,6 +105,7 @@ export function createRedoLog(container, fileData) {
   const checkbox = container.querySelector('#redolog-nonempty');
   const wrap = container.querySelector('#redolog-table-wrap');
   checkbox.addEventListener('change', () => {
+    trackFeatureUse('redolog_filter', { nonempty_only: checkbox.checked });
     wrap.innerHTML = renderBlockTable(report.blocks, checkbox.checked);
   });
 }

--- a/web/src/components/schema.js
+++ b/web/src/components/schema.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createSchema(container, fileData) {
   const wasm = getWasm();
@@ -53,6 +54,7 @@ export function createSchema(container, fileData) {
   const copyBtn = container.querySelector('#schema-copy-ddl');
   if (copyBtn && schema.ddl) {
     copyBtn.addEventListener('click', () => {
+      trackFeatureUse('copy_ddl');
       navigator.clipboard.writeText(schema.ddl).then(() => {
         copyBtn.textContent = 'Copied!';
         setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);

--- a/web/src/components/sdi.js
+++ b/web/src/components/sdi.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 export function createSdi(container, fileData) {
   const wasm = getWasm();
@@ -51,7 +52,7 @@ export function createSdi(container, fileData) {
     });
   });
 
-  container.querySelector('#sdi-expand-all').addEventListener('click', () => {
+  container.querySelector('#sdi-expand-all').addEventListener('click', () => { trackFeatureUse('sdi_expand_all');
     container.querySelectorAll('[id^="sdi-body-"]').forEach((el) => el.classList.remove('hidden'));
     container.querySelectorAll('.sdi-toggle').forEach((b) => (b.textContent = '-'));
   });

--- a/web/src/components/spatial.js
+++ b/web/src/components/spatial.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const CANVAS_W = 800;
 const CANVAS_H = 500;
@@ -119,6 +120,7 @@ export function createSpatial(container, fileData) {
     if (levelSelect) {
       levelSelect.addEventListener('change', () => {
         selectedLevel = parseInt(levelSelect.value, 10);
+        trackFeatureUse('spatial_level', { level: selectedLevel });
         drawMbrs(canvas, getMbrsForLevel(rtreePages, selectedLevel), bounds);
       });
     }

--- a/web/src/components/undelete.js
+++ b/web/src/components/undelete.js
@@ -3,6 +3,7 @@ import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar, downloadJson, downloadText } from '../utils/export.js';
 import { requestPage, navigateToTab } from '../utils/navigation.js';
+import { trackFeatureUse, trackExport } from '../utils/analytics.js';
 
 /**
  * Create the undelete tab for a single tablespace file.
@@ -129,6 +130,7 @@ export function createUndelete(container, fileData) {
   slider.addEventListener('input', () => {
     minConfidence = parseInt(slider.value, 10) / 100;
     confLabel.textContent = minConfidence.toFixed(2);
+    trackFeatureUse('undelete_confidence', { value: minConfidence });
     renderTable();
   });
 
@@ -166,6 +168,7 @@ function addDownloadButtons(bar, result, columns) {
           ? '"' + s.replace(/"/g, '""') + '"' : s;
       }).join(',')
     );
+    trackExport('csv', 'undelete');
     downloadText(csvLines.join('\n'), 'undelete.csv');
   });
 
@@ -174,6 +177,7 @@ function addDownloadButtons(bar, result, columns) {
   jsonBtn.className = 'px-3 py-1.5 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
   jsonBtn.textContent = 'Download JSON';
   jsonBtn.addEventListener('click', () => {
+    trackExport('json', 'undelete');
     downloadJson(result, 'undelete');
   });
 
@@ -182,6 +186,7 @@ function addDownloadButtons(bar, result, columns) {
   sqlBtn.className = 'px-3 py-1.5 bg-surface-3 hover:bg-gray-600 text-gray-300 rounded text-xs';
   sqlBtn.textContent = 'Download SQL';
   sqlBtn.addEventListener('click', () => {
+    trackExport('sql', 'undelete');
     const tableName = result.table_name || 'unknown_table';
     const colList = columns.join(', ');
     const lines = result.records.map(r => {

--- a/web/src/components/undo.js
+++ b/web/src/components/undo.js
@@ -2,6 +2,7 @@
 import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 /**
  * Create the undo tab for a single tablespace file.
@@ -73,6 +74,7 @@ export function createUndo(container, fileData) {
       const detailRow = tr.nextElementSibling;
       if (detailRow && detailRow.classList.contains('segment-detail')) {
         detailRow.classList.toggle('hidden');
+        trackFeatureUse('undo_segment_expand');
       }
     });
   });

--- a/web/src/components/verify.js
+++ b/web/src/components/verify.js
@@ -3,6 +3,7 @@ import { getWasm } from '../wasm.js';
 import { esc } from '../utils/html.js';
 import { createExportBar } from '../utils/export.js';
 import { requestPage, navigateToTab } from '../utils/navigation.js';
+import { trackFeatureUse } from '../utils/analytics.js';
 
 const PAGE_SIZE = 50;
 
@@ -82,7 +83,7 @@ export function createVerify(container, fileData) {
       // Click handler for findings rows
       wrap.querySelectorAll('tr[data-page-num]').forEach((tr) => {
         tr.classList.add('cursor-pointer');
-        tr.addEventListener('click', () => {
+        tr.addEventListener('click', () => { trackFeatureUse('verify_finding_click');
           const pageNum = parseInt(tr.dataset.pageNum, 10);
           if (!isNaN(pageNum)) {
             requestPage(pageNum);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -25,6 +25,7 @@ import { createSpatial } from './components/spatial.js';
 import { createUndelete } from './components/undelete.js';
 import { downloadJson } from './utils/export.js';
 import { initNavigation, requestPage, navigateToTab } from './utils/navigation.js';
+import { trackFileUpload, trackTabView, trackExport, trackFeatureUse, trackError, trackPerformance } from './utils/analytics.js';
 
 import './style.css';
 
@@ -45,9 +46,12 @@ initTheme();
 
 (async () => {
   showLoading('Loading WASM module...');
+  const wasmStart = performance.now();
   try {
     await initWasm();
+    trackPerformance('wasm_load', performance.now() - wasmStart);
   } catch (e) {
+    trackError('wasm_init', e);
     app.innerHTML = `<div class="flex-1 flex items-center justify-center text-red-400 p-8">
       <div class="text-center"><p class="text-lg mb-2">Failed to load WASM module</p><p class="text-sm text-gray-500">${esc(String(e))}</p></div>
     </div>`;
@@ -125,6 +129,7 @@ function onFile(name, data) {
     isBinlog = true;
     pageCount = 0;
     currentTab = 0;
+    trackFileUpload(name, data.length, 'binlog');
     renderAnalyzer();
     return;
   }
@@ -133,6 +138,7 @@ function onFile(name, data) {
   try {
     const info = JSON.parse(wasm.get_tablespace_info(data));
     pageCount = info.page_count;
+    trackFileUpload(name, data.length, 'tablespace');
 
     // Check for encryption
     if (info.is_encrypted) {
@@ -148,8 +154,10 @@ function onFile(name, data) {
       JSON.parse(wasm.parse_redo_log(data));
       isRedoLog = true;
       pageCount = 0;
+      trackFileUpload(name, data.length, 'redolog');
     } catch {
       pageCount = 0;
+      trackFileUpload(name, data.length, 'unknown');
     }
   }
 
@@ -172,6 +180,7 @@ function onDiffFiles(name1, data1, name2, data2) {
   } catch {
     pageCount = 0;
   }
+  trackFileUpload(name1, data1.length, 'diff');
   currentTab = 0;
   renderAnalyzer();
 }
@@ -192,6 +201,7 @@ function onMultiFiles(files) {
   } catch {
     pageCount = 0;
   }
+  trackFileUpload(files[0].name, files.reduce((s, f) => s + f.data.length, 0), 'multi-audit');
   // Auto-navigate to the Audit tab (last tab when audit mode is active)
   currentTab = getTabCount(tabOpts()) - 1;
   renderAnalyzer();
@@ -202,6 +212,7 @@ function onDecrypt(kData) {
     const wasm = getWasm();
     const result = wasm.decrypt_tablespace(fileData, kData);
     decryptedData = result;
+    trackFeatureUse('decryption', { success: true });
     // Update page count from decrypted data
     try {
       const info = JSON.parse(wasm.get_tablespace_info(decryptedData));
@@ -209,6 +220,8 @@ function onDecrypt(kData) {
     } catch { /* keep existing */ }
     renderAnalyzer();
   } catch (e) {
+    trackFeatureUse('decryption', { success: false });
+    trackError('decryption', e);
     // Show error in keyring area
     const errEl = document.getElementById('keyring-error');
     if (errEl) errEl.textContent = `Decryption failed: ${e}`;
@@ -325,6 +338,7 @@ function switchTab(index) {
   currentTab = index;
   const tabNav = app.querySelector('nav');
   if (tabNav) setActiveTab(tabNav, index);
+  trackTabView(getTabId(index, tabOpts()));
   renderTab();
 }
 
@@ -428,5 +442,6 @@ function exportAll() {
   try { const u = wasm.scan_deleted_records(data, -1n); if (u !== 'null') result.undelete = JSON.parse(u); } catch { /* skip */ }
 
   const baseName = fileName.replace(/\.[^.]+$/, '');
+  trackExport('json', 'export_all');
   downloadJson(result, `${baseName}_analysis`);
 }

--- a/web/src/utils/analytics.js
+++ b/web/src/utils/analytics.js
@@ -1,0 +1,46 @@
+// Centralized Google Analytics 4 event tracking
+// Thin wrapper around gtag() for consistent, privacy-respecting event tracking.
+
+/** Send a custom GA4 event. */
+export function trackEvent(name, params = {}) {
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', name, params);
+  }
+}
+
+/** Anonymize file info — only send extension and size, never the full name. */
+function anonymizeFile(name, size) {
+  const ext = name.includes('.') ? name.slice(name.lastIndexOf('.')) : 'unknown';
+  return { ext, size_kb: Math.round(size / 1024) };
+}
+
+/** Track a file upload event. */
+export function trackFileUpload(fileName, fileSize, fileType) {
+  const { ext, size_kb } = anonymizeFile(fileName, fileSize);
+  trackEvent('file_upload', { file_ext: ext, size_kb, file_type: fileType });
+}
+
+/** Track a tab view. */
+export function trackTabView(tabId) {
+  trackEvent('tab_view', { tab_id: tabId });
+}
+
+/** Track an export/download action. */
+export function trackExport(format, tabId) {
+  trackEvent('export', { format, tab_id: tabId });
+}
+
+/** Track a feature interaction. */
+export function trackFeatureUse(feature, details = {}) {
+  trackEvent('feature_use', { feature, ...details });
+}
+
+/** Track an error. */
+export function trackError(context, message) {
+  trackEvent('error', { context, message: String(message).slice(0, 100) });
+}
+
+/** Track a performance metric. */
+export function trackPerformance(metric, durationMs) {
+  trackEvent('performance', { metric, duration_ms: Math.round(durationMs) });
+}


### PR DESCRIPTION
## Summary

- Add Google Analytics 4 event tracking (Measurement ID: `G-SMQDMQW24Y`) to the idb-utils web UI
- Create centralized analytics module (`web/src/utils/analytics.js`) with privacy-respecting helpers that only send file extensions and sizes, never filenames
- Instrument all 18 component files plus `main.js` and `dropzone.js` with feature-specific tracking covering file uploads, tab views, exports, feature interactions, errors, and performance metrics

## GA4 Setup

- **Property**: "IDB Utils Web" (ID: 529337429) under `ryan@robworks.info` account
- **Data Stream**: "GitHub Pages" targeting `https://ringo380.github.io/idb-utils/`

## Events Tracked

| Category | Events |
|----------|--------|
| Core | `file_upload` (type, size), `tab_view`, `export`, `performance` (WASM load) |
| Features | `view_records`, `decoded_records`, `lob_chain`, `copy_ddl`, `copy_sql`, `hex_dump`, `btree_toggle`, `heatmap_mode`, `lsn_timeline_toggle`, `checksum_validation` |
| Filters | `audit_filter`, `binlog_filter`, `recovery_filter`, `redolog_filter`, `undelete_confidence`, `compat_version_select`, `spatial_level` |
| Navigation | `health_index_click`, `verify_finding_click`, `undo_segment_expand`, `sdi_expand_all` |
| Upload | `upload_method` (click vs drag-drop) |
| Errors | `wasm_init`, `decryption` failures |

## Test plan

- [ ] `cd web && npm run build` succeeds
- [ ] Open `web/dist/index.html`, check Network tab for gtag.js requests to googletagmanager.com
- [ ] Upload a test .ibd file → verify `file_upload` event in GA4 Realtime report
- [ ] Switch tabs, export data → verify `tab_view` and `export` events appear
- [ ] `cargo test` still passes (no Rust changes in this PR)