### PR TITLE
ci: run CI on PRs only and cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
 name: CI
 
 on:
-  push:
-    branches: [master, main]
   pull_request:
     branches: [master, main]
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always
+
+# Cancel superseded runs on the same PR branch so pushing several commits in a
+# row doesn't leave multiple builds (incl. the macos-latest leg) running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   fmt:


### PR DESCRIPTION
## Why

Cutting paid GitHub Actions spend. The `build` job matrix includes a `macos-latest` release build that ran on **both** push-to-default and every PR, with no `concurrency` group - so merged PRs paid for the macOS build twice and rapid pushes stacked runs.

## Changes (ci.yml)

- **Drop the `push` trigger** - validate on the PR; `workflow_dispatch` kept for manual runs.
- **Add `concurrency` with `cancel-in-progress`** so successive pushes to a PR branch cancel the older in-flight run (including the macOS leg).

All jobs and the build matrix are otherwise unchanged.

## Optional further cut

The `macos-latest` matrix leg is only a `cargo build --release` smoke check. If you don't need pre-release macOS build coverage (release.yml builds the actual artifacts), dropping `macos-latest` from the matrix would remove macOS minutes from this repo entirely. Left in for now - say the word and I'll drop it.