### PR TITLE
Fix misleading key_available in inno comply --encryption-audit

### DIFF
--- a/src/innodb/compliance.rs
+++ b/src/innodb/compliance.rs
@@ -570,7 +570,7 @@ pub struct EncryptionAuditReport {
 /// Audit which pages of a tablespace are encrypted and whether a key is available.
 pub fn encryption_audit(ts: &mut Tablespace) -> Result<EncryptionAuditReport, IdbError> {
     let tablespace_encrypted = ts.is_encrypted();
-    let key_available = ts.encryption_info().is_some();
+    let key_available = ts.has_decryption_key();
     let algorithm = if tablespace_encrypted {
         let flags = ts.fsp_header().map(|h| h.flags).unwrap_or(0);
         match crate::innodb::encryption::detect_encryption(flags, Some(ts.vendor_info())) {

--- a/src/innodb/tablespace.rs
+++ b/src/innodb/tablespace.rs
@@ -314,6 +314,14 @@ impl Tablespace {
         self.decryption_ctx = Some(ctx);
     }
 
+    /// Returns true if a decryption context (key) has actually been installed
+    /// via [`set_decryption_context`](Self::set_decryption_context). Unlike
+    /// [`is_encrypted`](Self::is_encrypted), this reflects whether the tablespace
+    /// can currently be decrypted, not merely whether it declares encryption.
+    pub fn has_decryption_key(&self) -> bool {
+        self.decryption_ctx.is_some()
+    }
+
     /// Read a single page by page number into a newly allocated buffer.
     ///
     /// If a decryption context has been set and the page has an encrypted


### PR DESCRIPTION
## Summary

`inno comply --encryption-audit` derived `key_available` from `encryption_info().is_some()`, which is exactly what `is_encrypted()` returns - both read the same page-0 encryption info. So the report showed `key available: yes` for any encrypted tablespace even when no `--keyring` was passed, giving the opposite of a useful signal in a forensic/compliance context.

## Fix

- Add `Tablespace::has_decryption_key()`, which returns whether a decryption context was actually installed via `set_decryption_context()` (i.e. a usable key is present).
- Use it for `key_available` in `encryption_audit()`.

Now an encrypted tablespace reports `key available: no` until a working `--keyring` is supplied, and `yes` once decryption is set up. Plaintext behavior is unchanged (still `no`).

## Testing

- `cargo fmt --check`, release build, and clippy clean on the changed files.
- Existing compliance/comply tests pass (13 lib + 17 integration).
- `--encryption-audit` on the plaintext fixture reports `Key available: no` as expected.

This was surfaced during review of #211 and left as a follow-up because it needed a new accessor on `tablespace.rs`.