### PR TITLE
Fix missing CSV header for empty data directory in inno audit

### DIFF
--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -604,6 +604,33 @@ pub fn execute(opts: &AuditOptions, writer: &mut dyn Write) -> Result<(), IdbErr
                     .map_err(|e| IdbError::Parse(format!("JSON serialization error: {}", e)))?;
                 wprintln!(writer, "{}", json)?;
             }
+        } else if opts.csv {
+            if opts.compliance {
+                wprintln!(writer, "file,match_count,pages_with_matches,capped,error")?;
+            } else if opts.health {
+                let do_bloat = opts.bloat || opts.max_bloat_grade.is_some();
+                if do_bloat {
+                    wprintln!(
+                        writer,
+                        "file,avg_fill_factor,avg_fragmentation,avg_garbage_ratio,index_count,total_index_pages,worst_bloat_grade,worst_bloat_score"
+                    )?;
+                } else {
+                    wprintln!(
+                        writer,
+                        "file,avg_fill_factor,avg_fragmentation,avg_garbage_ratio,index_count,total_index_pages"
+                    )?;
+                }
+            } else if opts.checksum_mismatch {
+                wprintln!(
+                    writer,
+                    "file,page_number,stored_checksum,calculated_checksum,algorithm"
+                )?;
+            } else {
+                wprintln!(
+                    writer,
+                    "file,status,total_pages,empty_pages,valid_pages,invalid_pages,lsn_mismatches"
+                )?;
+            }
         } else {
             wprintln!(writer, "No .ibd files found in {}", opts.datadir)?;
         }

--- a/tests/audit_test.rs
+++ b/tests/audit_test.rs
@@ -217,6 +217,39 @@ fn test_audit_empty_directory() {
 }
 
 #[test]
+fn test_audit_empty_directory_csv_emits_header() {
+    // An empty datadir with --format csv must emit the mode's CSV header (no rows),
+    // not the plain-text "No .ibd files found" message, so downstream parsers don't break.
+    let dir = TempDir::new().unwrap();
+    let datadir = dir.path().to_str().unwrap();
+
+    // Compliance mode.
+    let mut opts = audit_opts(datadir);
+    opts.csv = true;
+    opts.compliance = true;
+    opts.pattern = Some("alice".to_string());
+    let mut output = Vec::new();
+    idb::cli::audit::execute(&opts, &mut output).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(
+        text.trim(),
+        "file,match_count,pages_with_matches,capped,error"
+    );
+
+    // Default integrity mode.
+    let mut opts = audit_opts(datadir);
+    opts.csv = true;
+    let mut output = Vec::new();
+    idb::cli::audit::execute(&opts, &mut output).unwrap();
+    let text = String::from_utf8(output).unwrap();
+    assert_eq!(
+        text.trim(),
+        "file,status,total_pages,empty_pages,valid_pages,invalid_pages,lsn_mismatches"
+    );
+    assert!(!text.contains("No .ibd files found"));
+}
+
+#[test]
 fn test_audit_empty_directory_prometheus() {
     let dir = TempDir::new().unwrap();
     let datadir = dir.path().to_str().unwrap();


### PR DESCRIPTION
## Summary

`inno audit`'s empty-directory branch handled `--prometheus` and `--json` (with per-mode output) but had no `--csv` arm. So `inno audit --compliance --csv` - and every other mode under `--format csv` - printed the plain-text `No .ibd files found` message on an empty datadir instead of a valid CSV header, corrupting any downstream parser.

This is the same class of gap PR #118 fixed once for `--prometheus`. It was surfaced during review of #211 and deferred because it lived in the shared empty-files block rather than the compliance lines that PR added.

## Fix

Add an `else if opts.csv` arm that emits the same header the non-empty path uses for each mode (header only, no rows):

- compliance: `file,match_count,pages_with_matches,capped,error`
- health (with/without `--bloat`): the bloat-aware header
- checksum-mismatch: `file,page_number,stored_checksum,calculated_checksum,algorithm`
- default integrity: `file,status,total_pages,empty_pages,valid_pages,invalid_pages,lsn_mismatches`

Plain-text output (no `--csv`) is unchanged.

## Testing

- New `test_audit_empty_directory_csv_emits_header` covers compliance and default modes; mutation-checked (fails without the fix, passes with it).
- fmt/clippy clean on the changed file; full audit (23) and comply (17) suites pass.
- Verified all four modes emit the correct header against a real empty temp dir.